### PR TITLE
chore(deps): update gbfs-java-model to 1.0.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <maven.compiler.target>${jdk.version}</maven.compiler.target>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <gbfs-java-model.version>1.0.12</gbfs-java-model.version>
+        <gbfs-java-model.version>1.0.14</gbfs-java-model.version>
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>

--- a/src/main/java/org/entur/gbfs/mapper/VehicleTypesAdditionalMapper.java
+++ b/src/main/java/org/entur/gbfs/mapper/VehicleTypesAdditionalMapper.java
@@ -4,6 +4,7 @@ import org.mapstruct.Context;
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ValueMapping;
 
 import java.util.List;
 
@@ -14,6 +15,15 @@ public abstract class VehicleTypesAdditionalMapper {
 
     @InheritInverseConfiguration
     abstract org.mobilitydata.gbfs.v2_3.vehicle_types.GBFSVehicleType mapVehicleTypeInverse(org.mobilitydata.gbfs.v3_0.vehicle_types.GBFSVehicleType value, @Context String language);
+
+    // The deprecated v2.x "scooter" form factor was removed in v3.0; map it to its
+    // recommended replacement "scooter_standing". A dedicated inverse keeps every v3
+    // value mapping to its identically-named v2 counterpart (rather than inheriting
+    // the inverse of the value mapping above).
+    @ValueMapping(source = "SCOOTER", target = "SCOOTER_STANDING")
+    abstract org.mobilitydata.gbfs.v3_0.vehicle_types.GBFSVehicleType.FormFactor mapFormFactor(org.mobilitydata.gbfs.v2_3.vehicle_types.GBFSVehicleType.FormFactor value);
+
+    abstract org.mobilitydata.gbfs.v2_3.vehicle_types.GBFSVehicleType.FormFactor mapFormFactorInverse(org.mobilitydata.gbfs.v3_0.vehicle_types.GBFSVehicleType.FormFactor value);
 
     List<org.mobilitydata.gbfs.v3_0.vehicle_types.GBFSName> mapVehicleTypeName(String value, @Context String language) {
         if (value == null) {


### PR DESCRIPTION
Bumps `gbfs-java-model` 1.0.12 → 1.0.14.

## Why this needs a code change
1.0.14 removes the deprecated `scooter` form factor from the **v3.0** model (split into `scooter_standing`/`scooter_seated`), while the **v2.x** model retains it. This leaves the v2→v3 `FormFactor` enum mapping in `VehicleTypesAdditionalMapper` without a target for `SCOOTER`, which breaks compilation — this is the same failure currently red on Renovate PR #129.

## Fix
- `@ValueMapping(SCOOTER → SCOOTER_STANDING)` for the v2→v3 direction (the GBFS-recommended replacement for the deprecated value).
- A dedicated inverse method so every v3 value still maps to its identically-named v2 counterpart (no round-trip corruption for `scooter_standing`/`scooter_seated`).

Verified: `mvn verify` green on Java 17, all 43 tests pass. Generated impl confirmed: forward `SCOOTER → SCOOTER_STANDING`, inverse `SCOOTER_STANDING → SCOOTER_STANDING`.

Split out from the routine bumps in #129 because it carries real (model + mapper) behavior change.