### PR TITLE
chore(deps): version bumps for dependencies, plugins and CI actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,18 +19,18 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Copy maven settings
         run: |
           wget https://raw.githubusercontent.com/entur/ror-maven-settings/master/.m2/settings.xml -O .github/workflows/settings.xml
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 17.0.13
           distribution: liberica
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -55,13 +55,13 @@ jobs:
                   -Dsonar.host.url=https://sonarcloud.io \
                   -Dsonar.token=${SONAR_TOKEN}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           path: target/*.jar
   publish-release:
     if: github.repository_owner == 'entur' && github.event_name == 'push'
     name: Publish release to maven central
-    uses: entur/gha-maven-central/.github/workflows/maven-publish.yml@v1
+    uses: entur/gha-maven-central/.github/workflows/maven-publish.yml@v1.3.1
     secrets: inherit
     with:
       push_to_repo: true

--- a/pom.xml
+++ b/pom.xml
@@ -54,17 +54,17 @@
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+        <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
-        <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-        <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
-        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+        <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
+        <maven-site-plugin.version>3.22.0</maven-site-plugin.version>
+        <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
@@ -73,10 +73,10 @@
         <argLine />
 
         <!-- Unit test frameworks versions -->
-        <junit-jupiter.version>5.14.3</junit-jupiter.version>
+        <junit-jupiter.version>6.1.0</junit-jupiter.version>
         <java-snapshot-testing.version>4.0.8</java-snapshot-testing.version>
-        <jackson.version>2.21.2</jackson.version>
-        <slf4j-simple.version>2.0.17</slf4j-simple.version>
+        <jackson.version>2.22.0</jackson.version>
+        <slf4j-simple.version>2.0.18</slf4j-simple.version>
     </properties>
 
     <dependencies>
@@ -141,7 +141,7 @@
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-ssh-external</artifactId>
-                <version>2.12</version>
+                <version>3.5.3</version>
             </extension>
         </extensions>
         <pluginManagement>
@@ -255,7 +255,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>5.3.2</version>
+                <version>12.2.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -274,7 +274,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.12.0</version>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
@@ -290,7 +290,7 @@
             <plugin>
                 <groupId>org.jreleaser</groupId>
                 <artifactId>jreleaser-maven-plugin</artifactId>
-                <version>1.23.0</version>
+                <version>1.24.0</version>
                 <configuration>
                     <jreleaser>
                         <signing>


### PR DESCRIPTION
Consolidates the routine Renovate updates that build green without code changes. Supersedes the individual PRs listed below.

## Dependencies / test frameworks
- jackson 2.21.2 → 2.22.0
- junit-jupiter 5.14.3 → 6.1.0 (#113)
- slf4j-simple 2.0.17 → 2.0.18

## Build plugins
- maven-install-plugin 2.5.2 → 3.1.4 (#98)
- maven-deploy-plugin 2.8.2 → 3.1.4 (#97)
- maven-javadoc-plugin 2.10.4 → 3.12.0 (#99)
- dependency-check-maven 5.3.2 → 12.2.2 (#79)
- wagon-ssh-external 2.12 → 3.5.3 (#100)
- surefire / enforcer / site / jacoco / jreleaser patch bumps

## CI actions (deploy.yml)
- actions/checkout v4 → v6 (#121)
- actions/setup-java v4 → v5 (#106)
- actions/cache v4 → v5 (#123)
- actions/upload-artifact v4.6.2 → v7.0.1 (#115)
- gha-maven-central v1 → v1.3.1 (from pin PR #130)

Excludes the `gbfs-java-model` 1.0.14 bump, which requires a mapper change and is handled separately.

Verified: `mvn verify` green on Java 17, all 43 tests pass.